### PR TITLE
Fix: elixir 1.11 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Curve25519.Mixfile do
   end
 
   def application do
-    []
+    [extra_applications: [:crypto]]
   end
 
   defp deps do


### PR DESCRIPTION
Fix Elixir 1.11 warnings:

```shell
==> curve25519
Compiling 1 file (.ex)
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto]] to your "def project" in mix.exs

  lib/curve25519.ex:69: Curve25519.generate_key_pair/0
```